### PR TITLE
Clean up header, footer, and deduplicate content

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,18 +1,8 @@
 <footer class="site-footer">
-  <div class="footer-inner">
-    <div class="social-links">
-      <a href="https://github.com/alextnetto" target="_blank" rel="noopener noreferrer" aria-label="GitHub">
-        <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
-      </a>
-      <a href="https://t.me/alextnetto" target="_blank" rel="noopener noreferrer" aria-label="Telegram">
-        <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M11.944 0A12 12 0 000 12a12 12 0 0012 12 12 12 0 0012-12A12 12 0 0012 0a12 12 0 00-.056 0zm4.962 7.224c.1-.002.321.023.465.14a.506.506 0 01.171.325c.016.093.036.306.02.472-.18 1.898-.962 6.502-1.36 8.627-.168.9-.499 1.201-.82 1.23-.696.065-1.225-.46-1.9-.902-1.056-.693-1.653-1.124-2.678-1.8-1.185-.78-.417-1.21.258-1.91.177-.184 3.247-2.977 3.307-3.23.007-.032.014-.15-.056-.212s-.174-.041-.249-.024c-.106.024-1.793 1.14-5.061 3.345-.48.33-.913.49-1.302.48-.428-.008-1.252-.241-1.865-.44-.752-.245-1.349-.374-1.297-.789.027-.216.325-.437.893-.663 3.498-1.524 5.83-2.529 6.998-3.014 3.332-1.386 4.025-1.627 4.476-1.635z"/></svg>
-      </a>
-      <a href="https://www.linkedin.com/in/alextnetto" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn">
-        <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
-      </a>
-    </div>
-    <p class="footer-text">
-      <a href="https://github.com/alextnetto/alextnetto">source</a>
-    </p>
-  </div>
+  <nav class="footer-links">
+    <a href="https://github.com/alextnetto" target="_blank" rel="noopener noreferrer">github</a>
+    <a href="https://t.me/alextnetto" target="_blank" rel="noopener noreferrer">telegram</a>
+    <a href="https://www.linkedin.com/in/alextnetto" target="_blank" rel="noopener noreferrer">linkedin</a>
+    <a href="https://github.com/alextnetto/alextnetto">source</a>
+  </nav>
 </footer>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -4,26 +4,47 @@ const pathname = Astro.url.pathname;
 
 <header class="site-header">
   <nav>
-    <a href="/" class="site-name">alextnetto</a>
     <div class="nav-links">
       <a href="/" class:list={[{ active: pathname === '/' }]}>home</a>
       <a href="/blog" class:list={[{ active: pathname.startsWith('/blog') }]}>blog</a>
-      <button
-        class="theme-toggle"
-        aria-label="Toggle dark mode"
-        title="Toggle dark mode"
-      >
-        <span class="theme-icon-light">☀</span>
-        <span class="theme-icon-dark">☾</span>
-      </button>
     </div>
+    <button
+      class="theme-toggle"
+      aria-label="Toggle dark mode"
+      title="Toggle dark mode"
+    >
+      <span class="theme-icon-light">☀</span>
+      <span class="theme-icon-dark">☾</span>
+    </button>
   </nav>
 </header>
 
 <style>
+  .site-header nav {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 2rem;
+  }
+
+  .nav-links {
+    display: flex;
+    gap: 1.25rem;
+  }
+
+  .nav-links a {
+    font-size: 1rem;
+    color: var(--text-secondary);
+    text-decoration: none;
+  }
+
+  .nav-links a:hover {
+    color: var(--accent);
+  }
+
   .active {
-    color: var(--text);
-    font-weight: 700;
+    color: var(--text) !important;
+    font-weight: 600;
   }
 
   .theme-icon-dark {

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -68,8 +68,8 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
   </head>
   <body>
     <div class="page">
-      <Header />
       <main class="content">
+        <Header />
         <slot />
       </main>
       <Footer />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -60,31 +60,7 @@ const posts = (await getCollection('blog')).sort(
   </section>
 
   <section class="section">
-    <h2>Selected Projects</h2>
-
-    <div class="project-item">
-      <strong><a href="https://etherscan.io/address/0xb8fa0ce3f91f41c5292d07475b445c35ddf63ee0#code">ENS Security Council</a></strong>
-      <p>Smart contract development protecting a ~$2B DAO treasury. Authored the <a href="https://discuss.ens.domains/t/temp-check-enable-cancel-role-on-the-dao/19090">governance proposal</a> and led security research.</p>
-    </div>
-
-    <div class="project-item">
-      <strong><a href="/blog/kqf">Knapsack Quadratic Funding (KQF)</a></strong>
-      <p>Research on an alternative funding mechanism that improves accountability and resource allocation efficiency.</p>
-    </div>
-
-    <div class="project-item">
-      <strong><a href="https://github.com/metagov/daostar/blob/main/DAOIPs/daoip-6.md">DAOIP-6</a></strong>
-      <p>Co-authored a DAO interoperability standard for grant program reporting via Metagov/DAOstar.</p>
-    </div>
-
-    <div class="project-item">
-      <strong>Compound Governance Research</strong>
-      <p>Analysis of governance attack vectors in the Compound protocol.</p>
-    </div>
-  </section>
-
-  <section class="section">
-    <h2>Open Source</h2>
+    <h2>Open Source & Contributions</h2>
 
     <div class="achievement-group">
       <h3>Projects</h3>
@@ -97,11 +73,6 @@ const posts = (await getCollection('blog')).sort(
       <div class="project-item">
         <strong><a href="https://github.com/blockful/dao-proposals">dao-proposals</a></strong>
         <p>ENS governance proposal review framework. Calldata decoding, verification, and security analysis for on-chain proposals protecting a ~$2B treasury.</p>
-      </div>
-
-      <div class="project-item">
-        <strong><a href="https://github.com/blockful/shutter-security-council">shutter-security-council</a></strong>
-        <p>Security council implementation with Shutter encrypted voting and Hats Protocol proposal gating.</p>
       </div>
 
       <div class="project-item">
@@ -133,10 +104,6 @@ const posts = (await getCollection('blog')).sort(
         <p>Added <code>docs comments</code> subcommand for managing Google Doc comments to this Google Suite CLI tool.</p>
       </div>
 
-      <div class="project-item">
-        <strong><a href="https://github.com/openclaw/openclaw/pull/16441">openclaw</a></strong>
-        <p>Contributing Telegram forum topic matching and auth UX improvements to this open-source AI assistant platform.</p>
-      </div>
     </div>
   </section>
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -86,56 +86,6 @@ body {
   padding: 2rem 1.25rem 4rem;
 }
 
-/* --- Navigation --- */
-.site-header {
-  position: sticky;
-  top: 0;
-  z-index: 100;
-  background: var(--bg);
-  border-bottom: 1px solid var(--border-light);
-  transition: background-color 0.3s ease, border-color 0.3s ease;
-}
-
-.site-header nav {
-  max-width: 720px;
-  margin: 0 auto;
-  padding: 0.75rem 1.25rem;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-.site-name {
-  font-family: 'JetBrains Mono', 'SF Mono', 'Consolas', monospace;
-  font-size: 0.95rem;
-  font-weight: 700;
-  color: var(--text);
-  text-decoration: none;
-  letter-spacing: -0.02em;
-}
-
-.site-name:hover {
-  color: var(--accent);
-}
-
-.nav-links {
-  display: flex;
-  align-items: center;
-  gap: 1.25rem;
-}
-
-.nav-links a {
-  font-family: 'JetBrains Mono', 'SF Mono', 'Consolas', monospace;
-  font-size: 0.8rem;
-  color: var(--text-secondary);
-  text-decoration: none;
-  letter-spacing: 0.02em;
-}
-
-.nav-links a:hover {
-  color: var(--accent);
-}
-
 /* --- Theme Toggle --- */
 .theme-toggle {
   background: none;
@@ -343,49 +293,24 @@ abbr[title] {
 .site-footer {
   border-top: 1px solid var(--border-light);
   padding: 2rem 1.25rem;
-  text-align: center;
+  max-width: 720px;
+  margin: 0 auto;
   transition: border-color 0.3s ease;
 }
 
-.site-footer .footer-inner {
-  max-width: 720px;
-  margin: 0 auto;
-}
-
-.social-links {
+.footer-links {
   display: flex;
-  justify-content: center;
-  gap: 1.5rem;
-  margin-bottom: 1rem;
+  gap: 1.25rem;
+  flex-wrap: wrap;
 }
 
-.social-links a {
+.footer-links a {
+  font-size: 0.95rem;
   color: var(--text-muted);
   text-decoration: none;
-  transition: color 0.2s;
 }
 
-.social-links a:hover {
-  color: var(--accent);
-}
-
-.social-links svg {
-  width: 20px;
-  height: 20px;
-  fill: currentColor;
-}
-
-.footer-text {
-  font-size: 0.8rem;
-  color: var(--text-muted);
-  font-family: 'JetBrains Mono', monospace;
-}
-
-.footer-text a {
-  color: var(--text-muted);
-}
-
-.footer-text a:hover {
+.footer-links a:hover {
   color: var(--accent);
 }
 
@@ -502,7 +427,6 @@ abbr[title] {
 
 /* --- Print --- */
 @media print {
-  .site-header,
   .site-footer,
   .theme-toggle,
   .post-nav {


### PR DESCRIPTION
## Summary
- **Header**: Replace sticky monospace bar with inline serif nav — `home` and `blog` links + theme toggle are now part of the content flow, same font as the rest of the page
- **Footer**: Simplify from SVG icon grid to clean text links (github, telegram, linkedin, source)
- **Deduplicate**: Remove "Selected Projects" section — ENS Security Council already covered in Experience/Now, DAOIP-6 in Open Source, KQF in Writing
- **Rename** "Open Source" → "Open Source & Contributions"
- **Remove** shutter-security-council and openclaw entries

## Test plan
- [x] Header renders inline with serif font, no sticky bar
- [x] Footer shows 4 text links, left-aligned
- [x] 9 sections total (Selected Projects removed)
- [x] Open Source & Contributions: 5 projects + 2 contributions
- [x] No build errors
- [x] Theme toggle still works