### PR TITLE
Content and layout refinements

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -3,11 +3,11 @@ const pathname = Astro.url.pathname;
 ---
 
 <header class="site-header">
-  <nav>
-    <div class="nav-links">
+  <div class="header-right">
+    <nav class="nav-links">
       <a href="/" class:list={[{ active: pathname === '/' }]}>home</a>
       <a href="/blog" class:list={[{ active: pathname.startsWith('/blog') }]}>blog</a>
-    </div>
+    </nav>
     <button
       class="theme-toggle"
       aria-label="Toggle dark mode"
@@ -16,15 +16,21 @@ const pathname = Astro.url.pathname;
       <span class="theme-icon-light">☀</span>
       <span class="theme-icon-dark">☾</span>
     </button>
-  </nav>
+  </div>
 </header>
 
 <style>
-  .site-header nav {
+  .site-header {
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-end;
     align-items: center;
-    margin-bottom: 2rem;
+    margin-bottom: 0.25rem;
+  }
+
+  .header-right {
+    display: flex;
+    align-items: center;
+    gap: 1.25rem;
   }
 
   .nav-links {

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -10,7 +10,7 @@ interface Props {
 
 const {
   title = 'Alexandro Netto',
-  description = 'Founder & CEO of blockful. Building at the intersection of software, security, and financial infrastructure.',
+  description = 'Founder & CEO of blockful. Working at the intersection of game theory, economy, and bytes.',
 } = Astro.props;
 
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
@@ -71,8 +71,8 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
       <main class="content">
         <Header />
         <slot />
+        <Footer />
       </main>
-      <Footer />
     </div>
   </body>
 </html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,10 +10,8 @@ const posts = (await getCollection('blog')).sort(
 <Base>
   <div class="hero">
     <h1>Alex Netto</h1>
-    <p class="tagline">Founder & CEO building at the intersection of software, security, and financial infrastructure.</p>
+    <p class="tagline">Working at the intersection of game theory, economy, and bytes.</p>
   </div>
-
-  <hr />
 
   <section class="section">
     <h2>About</h2>
@@ -31,7 +29,6 @@ const posts = (await getCollection('blog')).sort(
       <li>CEO & Founder at <strong>blockful</strong> — security and infrastructure</li>
       <li>ENS Delegate and Security Council member, protecting a ~$2B treasury</li>
       <li>Researching mechanism design, governance, and public goods funding</li>
-      <li><a href="https://www.youtube.com/watch?v=RyEVflEF_qY">Stanford invited speaker</a> (2025, confirmed 2026)</li>
     </ul>
   </section>
 
@@ -85,18 +82,29 @@ const posts = (await getCollection('blog')).sort(
         <p>Secure personal data sharing with expiring links.</p>
       </div>
 
-      <div class="project-item">
-        <strong><a href="https://github.com/metagov/daostar/blob/main/DAOIPs/daoip-6.md">DAOIP-6</a></strong>
-        <p>Co-authored a DAO interoperability standard for grant program reporting via Metagov/DAOstar.</p>
-      </div>
     </div>
 
     <div class="achievement-group">
       <h3>Contributions</h3>
 
       <div class="project-item">
+        <strong><a href="https://paragraph.com/@blockful/a-hidden-threat-to-ens-uncovering-and-solving-a-major-governanc">ENS governance vulnerability</a></strong>
+        <p>Discovered and responsibly disclosed a vulnerability that could have enabled a ~$150M attack on ENS DAO governance.</p>
+      </div>
+
+      <div class="project-item">
+        <strong><a href="https://eips.ethereum.org/EIPS/eip-7884">ERC-7884: Operation Router</a></strong>
+        <p>Co-authored Ethereum standard enabling smart contracts to redirect write operations to L2 chains, L1, or off-chain databases.</p>
+      </div>
+
+      <div class="project-item">
+        <strong><a href="https://github.com/metagov/daostar/blob/main/DAOIPs/daoip-6.md">DAOIP-6</a></strong>
+        <p>Co-authored a DAO interoperability standard for grant program reporting via Metagov/DAOstar.</p>
+      </div>
+
+      <div class="project-item">
         <strong><a href="https://github.com/safe-global/safe-wallet-monorepo/pull/7124">Safe&#123;Wallet&#125;</a></strong>
-        <p>Added ENS name resolution to account list items. Merged into the main Safe smart account wallet used by thousands of teams.</p>
+        <p>Added ENS name resolution to account list items. Merged into the main Safe smart account wallet.</p>
       </div>
 
       <div class="project-item">
@@ -159,7 +167,7 @@ const posts = (await getCollection('blog')).sort(
   <section class="section">
     <h2>Education</h2>
     <p>
-      Computer Science — Federal University of Santa Catarina (UFSC), Florianópolis, Brazil.
+      Computer Science (3 years, dropout) — Federal University of Santa Catarina (UFSC), Florianópolis, Brazil.
     </p>
   </section>
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -83,7 +83,7 @@ body {
   width: 100%;
   max-width: 720px;
   margin: 0 auto;
-  padding: 2rem 1.25rem 4rem;
+  padding: 1rem 1.25rem 4rem;
 }
 
 /* --- Theme Toggle --- */
@@ -292,9 +292,8 @@ abbr[title] {
 /* --- Footer --- */
 .site-footer {
   border-top: 1px solid var(--border-light);
-  padding: 2rem 1.25rem;
-  max-width: 720px;
-  margin: 0 auto;
+  padding-top: 0.75rem;
+  margin-top: 1rem;
   transition: border-color 0.3s ease;
 }
 
@@ -334,6 +333,11 @@ abbr[title] {
 .section h2 {
   font-size: 1.3rem;
   margin-bottom: 0.75rem;
+}
+
+.section:first-of-type h2 {
+  border-top: none;
+  padding-top: 0;
 }
 
 .project-item {
@@ -463,7 +467,7 @@ abbr[title] {
   }
 
   .content {
-    padding: 3rem 2rem 5rem;
+    padding: 1.5rem 2rem 5rem;
   }
 
   .hero h1 {


### PR DESCRIPTION
## Summary
- Update tagline to "game theory, economy, and bytes"
- Remove Stanford emphasis from Now section (kept in Speaking & Teaching)
- Add ERC-7884, ENS governance vulnerability, move DAOIP-6 to Contributions
- Fix duplicated divider at top, fix footer divider width
- Right-align nav, reduce top margin and footer spacing
- Update Education to mention dropout

## Test plan
- [ ] Homepage renders with new tagline
- [ ] No duplicate dividers at top
- [ ] Footer divider matches section dividers width